### PR TITLE
Use post rather than get requests to avoid possible URL length issue

### DIFF
--- a/eagleSqlTools/_eagleSqlTools.py
+++ b/eagleSqlTools/_eagleSqlTools.py
@@ -60,9 +60,10 @@ class _WebDBConnection:
 
     def _execute_query(self, sql):
         """Run an SQL query and return the result as a record array"""
-        url = self.db_url + "?" + urlencode({'action': 'doQuery', 'SQL': sql})
+        data = urlencode({'action':'doQuery', 'queryMode':'stream', 'SQL':sql,})
+        url = self.db_url + "/MyDB"
         install_opener(build_opener(self.auth_handler, self.cookie_handler))
-        response = urlopen(url)
+        response = urlopen(url, data=data)
         cookie_jar.save(ignore_discard=True)
 
         # Check for OK response

--- a/eagleSqlTools/_eagleSqlTools.py
+++ b/eagleSqlTools/_eagleSqlTools.py
@@ -63,7 +63,7 @@ class _WebDBConnection:
         data = urlencode({'action':'doQuery', 'queryMode':'stream', 'SQL':sql,})
         url = self.db_url + "/MyDB"
         install_opener(build_opener(self.auth_handler, self.cookie_handler))
-        response = urlopen(url, data=data)
+        response = urlopen(url, data=data.encode('utf-8'))
         cookie_jar.save(ignore_discard=True)
 
         # Check for OK response


### PR DESCRIPTION
We've had some problems with queries from sites other than Durham not reaching the database server when using the python module. The urlopen call times out waiting for a response and there's no record of the query in the server log.

The problem only seems to happen with long query strings and it never happens with queries submitted with a browser. It turns out that browsers submit post requests but eagleSqlTools uses get requests with the query embedded in the URL, so maybe we're hitting a limitation on the length of URL parameters. This PR modifies eagleSqlTools to use post requests instead, which solves the problem in the cases where we've tested it so far.