### PR TITLE
fix line concatenate type error

### DIFF
--- a/eagleSqlTools/_eagleSqlTools.py
+++ b/eagleSqlTools/_eagleSqlTools.py
@@ -97,7 +97,7 @@ class _WebDBConnection:
                 if m is not None:
                     columns.append(m.groups())
                 else:
-                    raise Exception("Don't understand column info: "+line.decode("utf-8"))
+                    raise Exception("Don't understand column info: " + line.decode())
 
         # Construct record type for the output
         types = [numpy_dtype[col[3]] for col in columns]

--- a/eagleSqlTools/_eagleSqlTools.py
+++ b/eagleSqlTools/_eagleSqlTools.py
@@ -97,7 +97,7 @@ class _WebDBConnection:
                 if m is not None:
                     columns.append(m.groups())
                 else:
-                    raise Exception("Don't understand column info: "+line)
+                    raise Exception("Don't understand column info: "+line.decode("utf-8"))
 
         # Construct record type for the output
         types = [numpy_dtype[col[3]] for col in columns]


### PR DESCRIPTION
### Problem recurrence
the query
```sql
SELECT SUM(SH.StellarInitialMass) FROM ...
```

The SUM returns with no name of the column, which will invoke the exception at `Read column info`

### Fix
When the program raises an exception at `Read column info`, `line` will be appended to the message, where `line` is a byte string that cannot be concatenated with a string directly.

So the complier will throw TypeError:

![image](https://user-images.githubusercontent.com/15688641/127554412-593ae15c-1253-40dd-94f9-440703441fb2.png)

After the decoding of bytes, it shows the message correctly.

![image](https://user-images.githubusercontent.com/15688641/127555435-c2a13799-5aef-4036-ba9b-a7483afc3be8.png)
